### PR TITLE
Remove space between number and unit in bake ingredient amounts

### DIFF
--- a/src/pages/baking/[id].astro
+++ b/src/pages/baking/[id].astro
@@ -57,7 +57,7 @@ const schedule = data.schedule.toSorted((a, b) => a.sort_order - b.sort_order)
           {
             ingredients.map((ing) => (
               <li>
-                {ing.amount} {ing.name}
+                {ing.amount.replace(/\s+(?=[a-zA-Z%]+$)/, '')} {ing.name}
                 {ing.note && <span> — {ing.note}</span>}
               </li>
             ))


### PR DESCRIPTION
Strip whitespace before the trailing unit in ingredient amounts
so they render as "50g" instead of "50 g".

https://claude.ai/code/session_01YapDAkLkRWhyFpjRsYyJga