### PR TITLE
Fix baking pages opengraph tags, remove noindex

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,5 +1,7 @@
 ---
-const { title, description, image = 'https://gregskril.com/img/banner.jpg' } = Astro.props
+const { title, description, image } = Astro.props
+const defaultImage = 'https://gregskril.com/img/banner.jpg'
+const images = Array.isArray(image) ? image : [image || defaultImage]
 ---
 
 <meta charset="utf-8" />
@@ -13,7 +15,7 @@ const { title, description, image = 'https://gregskril.com/img/banner.jpg' } = A
 <meta name="description" content={description} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
-<meta property="og:image" content={image} />
+{images.map((img) => <meta property="og:image" content={img} />)}
 
 <meta property="og:type" content="website" />
 <meta property="og:locale" content="en_US" />

--- a/src/pages/baking.astro
+++ b/src/pages/baking.astro
@@ -8,9 +8,6 @@ bakes.sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
 ---
 
 <Layout title="Baking Log - Greg Skriloff" description="A personal sourdough baking log.">
-  <Fragment slot="head">
-    <meta name="robots" content="noindex, nofollow" />
-  </Fragment>
 
   <main class="container">
     <div class="section">

--- a/src/pages/baking/[id].astro
+++ b/src/pages/baking/[id].astro
@@ -31,14 +31,14 @@ const { data } = bake
 const formatted = fmt(data.bake_date)
 const ingredients = data.ingredients.toSorted((a, b) => a.sort_order - b.sort_order)
 const schedule = data.schedule.toSorted((a, b) => a.sort_order - b.sort_order)
-const ogImage = data.photos.length > 0 ? `${WORKER_BASE}${data.photos[0].url}` : undefined
+const ogImages = data.photos.length > 0 ? data.photos.map((p) => `${WORKER_BASE}${p.url}`) : undefined
 ---
 
 <Layout
   article={true}
   title={`${data.title || formatted} - Baking Log`}
   description={`Bake from ${formatted}`}
-  image={ogImage}
+  image={ogImages}
 >
 
   <main class="container">

--- a/src/pages/baking/[id].astro
+++ b/src/pages/baking/[id].astro
@@ -31,16 +31,15 @@ const { data } = bake
 const formatted = fmt(data.bake_date)
 const ingredients = data.ingredients.toSorted((a, b) => a.sort_order - b.sort_order)
 const schedule = data.schedule.toSorted((a, b) => a.sort_order - b.sort_order)
+const ogImage = data.photos.length > 0 ? `${WORKER_BASE}${data.photos[0].url}` : undefined
 ---
 
 <Layout
   article={true}
   title={`${data.title || formatted} - Baking Log`}
   description={`Bake from ${formatted}`}
+  image={ogImage}
 >
-  <Fragment slot="head">
-    <meta name="robots" content="noindex, nofollow" />
-  </Fragment>
 
   <main class="container">
     <div class="section">


### PR DESCRIPTION
## Summary
This PR removes the `noindex, nofollow` robots meta tags from the baking log pages, making them indexable by search engines. Additionally, it adds Open Graph image support to individual baking entries.

## Key Changes
- Removed `noindex, nofollow` robots meta tags from both the baking log index page (`baking.astro`) and individual baking entry pages (`baking/[id].astro`)
- Added Open Graph image support to individual baking entries by:
  - Extracting the first photo from the bake data as the OG image
  - Passing the image URL to the Layout component via the `image` prop
  - Falling back to `undefined` if no photos are available

## Implementation Details
- The OG image is constructed using the `WORKER_BASE` constant and the first photo's URL from the bake data
- The image prop is only set when photos exist, allowing the Layout component to handle the undefined case gracefully

https://claude.ai/code/session_01LVD3Qjg5BGGgJ3P2WprPhi