### PR TITLE
Add rpc-monitor project

### DIFF
--- a/src/content/projects/rpc-monitor.md
+++ b/src/content/projects/rpc-monitor.md
@@ -1,7 +1,7 @@
 ---
 title: RPC Monitor
 date: 2026-03-29
-url: https://github.com/gskril/rpc-monitor
+url: https://rpc-monitor.gregskril.com/
 ---
 
 Dashboard for comparing RPC provider latency and availability across regions.

--- a/src/content/projects/rpc-monitor.md
+++ b/src/content/projects/rpc-monitor.md
@@ -4,4 +4,4 @@ date: 2026-03-29
 url: https://github.com/gskril/rpc-monitor
 ---
 
-Measures RPC provider latency across Railway regions using a consistent `eth_call`, stores results in Postgres, and exposes a dashboard for comparing latency and availability over time.
+Dashboard for comparing RPC provider latency and availability across regions.

--- a/src/content/projects/rpc-monitor.md
+++ b/src/content/projects/rpc-monitor.md
@@ -1,0 +1,7 @@
+---
+title: RPC Monitor
+date: 2026-03-29
+url: https://github.com/gskril/rpc-monitor
+---
+
+Measures RPC provider latency across Railway regions using a consistent `eth_call`, stores results in Postgres, and exposes a dashboard for comparing latency and availability over time.


### PR DESCRIPTION
Adds the [rpc-monitor](https://github.com/gskril/rpc-monitor) project to the projects content collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)